### PR TITLE
Fix compilation error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+            <version>3.9.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
This PR fixes a compilation error by adding the `connect-json` and `jackson-databind` dependencies to the `pom.xml` file.